### PR TITLE
WHY-2652,WHY-2686: user can specify null check values

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,5 +196,11 @@ val profiles = df.newProfilingSession("PprofilingSession") // start a new WhyLog
 For further analysis, dataframes can be stored in a Parquet file, or collected to the driver if the number of entries is small enough.
 
 ## Building and Testing
+
+Before building, update the `proto` submodule,
+```
+git submodule update --init --recursive
+```
+
 * To build, run `./gradlew build`
 * To test, run `./gradlew test`

--- a/core/src/main/java/com/whylogs/core/ColumnProfile.java
+++ b/core/src/main/java/com/whylogs/core/ColumnProfile.java
@@ -170,6 +170,7 @@ public class ColumnProfile {
         .setCardinalityTracker(
             HllSketch.heapify(message.getCardinalityTracker().getSketch().toByteArray()))
         .setFrequentItems(FrequentStringsSketch.deserialize(message.getFrequentItems().getSketch()))
+        .setNullStrs(ImmutableSet.of())
         .build();
   }
 }

--- a/core/src/main/java/com/whylogs/core/ColumnProfile.java
+++ b/core/src/main/java/com/whylogs/core/ColumnProfile.java
@@ -6,6 +6,7 @@ import static com.whylogs.core.types.TypedDataConverter.NUMERIC_TYPES;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import com.google.protobuf.ByteString;
 import com.whylogs.core.message.ColumnMessage;
 import com.whylogs.core.message.ColumnSummary;
@@ -142,7 +143,7 @@ public class ColumnProfile {
         .setSchemaTracker(this.schemaTracker.merge(other.schemaTracker))
         .setCardinalityTracker(HllSketch.heapify(mergedSketch.toCompactByteArray()))
         .setFrequentItems(copyFreqItems)
-        .setNullStrs(other.getNullStrs())
+        .setNullStrs(Sets.union(this.getNullStrs(), other.getNullStrs()).immutableCopy())
         .build();
   }
 
@@ -170,7 +171,7 @@ public class ColumnProfile {
         .setCardinalityTracker(
             HllSketch.heapify(message.getCardinalityTracker().getSketch().toByteArray()))
         .setFrequentItems(FrequentStringsSketch.deserialize(message.getFrequentItems().getSketch()))
-        .setNullStrs(ImmutableSet.of())
+        .setNullStrs(ColumnProfile.nullStrsFromEnv())
         .build();
   }
 }

--- a/core/src/main/java/com/whylogs/core/ColumnProfile.java
+++ b/core/src/main/java/com/whylogs/core/ColumnProfile.java
@@ -5,7 +5,7 @@ import static com.whylogs.core.statistics.datatypes.StringTracker.ARRAY_OF_STRIN
 import static com.whylogs.core.types.TypedDataConverter.NUMERIC_TYPES;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Sets;
+import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.ByteString;
 import com.whylogs.core.message.ColumnMessage;
 import com.whylogs.core.message.ColumnSummary;
@@ -15,8 +15,6 @@ import com.whylogs.core.statistics.NumberTracker;
 import com.whylogs.core.statistics.SchemaTracker;
 import com.whylogs.core.types.TypedDataConverter;
 import com.whylogs.core.utils.sketches.FrequentStringsSketch;
-import java.util.Collections;
-import java.util.Set;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -34,7 +32,7 @@ import org.apache.datasketches.memory.Memory;
 public class ColumnProfile {
   public static final int FREQUENT_MAX_LG_K = 7;
   private static final int CARDINALITY_LG_K = 12;
-  private static volatile Set<String> NULL_STR_ENVS;
+  private static volatile ImmutableSet<String> NULL_STR_ENVS;
 
   @NonNull private final String columnName;
   @NonNull private final CountersTracker counters;
@@ -42,13 +40,13 @@ public class ColumnProfile {
   @NonNull private final NumberTracker numberTracker;
   @NonNull private final ItemsSketch<String> frequentItems;
   @NonNull private final HllSketch cardinalityTracker;
-  @NonNull private final Set<String> nullStrs;
+  @NonNull private final ImmutableSet<String> nullStrs;
 
-  static Set<String> nullStrsFromEnv() {
+  static ImmutableSet<String> nullStrsFromEnv() {
     if (ColumnProfile.NULL_STR_ENVS == null) {
       val nullSpec = System.getenv("NULL_STRINGS");
       ColumnProfile.NULL_STR_ENVS =
-          nullSpec == null ? Collections.emptySet() : Sets.newHashSet(nullSpec.split(","));
+          nullSpec == null ? ImmutableSet.of() : ImmutableSet.copyOf(nullSpec.split(","));
     }
     return ColumnProfile.NULL_STR_ENVS;
   }
@@ -57,7 +55,7 @@ public class ColumnProfile {
     this(columnName, nullStrsFromEnv());
   }
 
-  public ColumnProfile(String columnName, Set<String> nullStrs) {
+  public ColumnProfile(String columnName, ImmutableSet<String> nullStrs) {
     this.columnName = columnName;
     this.counters = new CountersTracker();
     this.schemaTracker = new SchemaTracker();

--- a/core/src/main/java/com/whylogs/core/ColumnProfile.java
+++ b/core/src/main/java/com/whylogs/core/ColumnProfile.java
@@ -71,7 +71,7 @@ public class ColumnProfile {
     synchronized (this) {
       counters.incrementCount();
 
-      if (value == null || this.nullStrs.contains(value.toString())) {
+      if (value == null || (!this.nullStrs.isEmpty() && this.nullStrs.contains(value.toString()))) {
         counters.incrementNull();
         return;
       }
@@ -144,6 +144,7 @@ public class ColumnProfile {
         .setSchemaTracker(this.schemaTracker.merge(other.schemaTracker))
         .setCardinalityTracker(HllSketch.heapify(mergedSketch.toCompactByteArray()))
         .setFrequentItems(copyFreqItems)
+        .setNullStrs(other.getNullStrs())
         .build();
   }
 

--- a/core/src/test/java/com/whylogs/core/ColumnProfileTest.java
+++ b/core/src/test/java/com/whylogs/core/ColumnProfileTest.java
@@ -3,7 +3,7 @@ package com.whylogs.core;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-import com.google.common.collect.Sets;
+import com.google.common.collect.ImmutableSet;
 import lombok.val;
 import org.testng.annotations.Test;
 
@@ -29,7 +29,7 @@ public class ColumnProfileTest {
   /** Check that custom null specification detects nulls and has no false positives. */
   @Test
   public void column_NullTest_ShouldWork() {
-    val col = new ColumnProfile("test", Sets.newHashSet("nil", "NaN", "nan", "null"));
+    val col = new ColumnProfile("test", ImmutableSet.of("nil", "NaN", "nan", "null"));
     col.track(1L);
     col.track(1.0);
     col.track("string");

--- a/core/src/test/java/com/whylogs/core/ColumnProfileTest.java
+++ b/core/src/test/java/com/whylogs/core/ColumnProfileTest.java
@@ -3,7 +3,7 @@ package com.whylogs.core;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
 import lombok.val;
 import org.testng.annotations.Test;
 
@@ -29,7 +29,7 @@ public class ColumnProfileTest {
   /** Check that custom null specification detects nulls and has no false positives. */
   @Test
   public void column_NullTest_ShouldWork() {
-    val col = new ColumnProfile("test", ImmutableList.copyOf("nil.NaN,nan,null".split(",")));
+    val col = new ColumnProfile("test", Sets.newHashSet("nil", "NaN", "nan", "null"));
     col.track(1L);
     col.track(1.0);
     col.track("string");

--- a/core/src/test/java/com/whylogs/core/ColumnProfileTest.java
+++ b/core/src/test/java/com/whylogs/core/ColumnProfileTest.java
@@ -3,6 +3,7 @@ package com.whylogs.core;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+import com.google.common.collect.ImmutableList;
 import lombok.val;
 import org.testng.annotations.Test;
 
@@ -28,8 +29,7 @@ public class ColumnProfileTest {
   /** Check that custom null specification detects nulls and has no false positives. */
   @Test
   public void column_NullTest_ShouldWork() {
-    ColumnProfile.initNullCheck("nil.NaN,nan,null");
-    val col = new ColumnProfile("test");
+    val col = new ColumnProfile("test", ImmutableList.copyOf("nil.NaN,nan,null".split(",")));
     col.track(1L);
     col.track(1.0);
     col.track("string");

--- a/core/src/test/java/com/whylogs/core/ColumnProfileTest.java
+++ b/core/src/test/java/com/whylogs/core/ColumnProfileTest.java
@@ -25,6 +25,28 @@ public class ColumnProfileTest {
     assertThat(col.getNumberTracker().getDoubles().getCount(), is(2L));
   }
 
+  /** Check that custom null specification detects nulls and has no false positives. */
+  @Test
+  public void column_NullTest_ShouldWork() {
+    ColumnProfile.initNullCheck("nil.NaN,nan,null");
+    val col = new ColumnProfile("test");
+    col.track(1L);
+    col.track(1.0);
+    col.track("string");
+    col.track(true);
+    col.track(false);
+    col.track(null);
+    col.track("nil.NaN");
+    col.track("nan");
+    col.track("null");
+
+    assertThat(col.getCounters().getCount(), is(9L));
+    assertThat(col.getCounters().getNullCount(), is(4L));
+    assertThat(col.getCounters().getTrueCount(), is(1L));
+    assertThat(col.getNumberTracker().getLongs().getCount(), is(0L));
+    assertThat(col.getNumberTracker().getDoubles().getCount(), is(2L));
+  }
+
   @Test
   public void column_Merge_Success() {
     val col = new ColumnProfile("test");

--- a/core/src/test/java/com/whylogs/core/ColumnProfileTest.java
+++ b/core/src/test/java/com/whylogs/core/ColumnProfileTest.java
@@ -36,12 +36,13 @@ public class ColumnProfileTest {
     col.track(true);
     col.track(false);
     col.track(null);
-    col.track("nil.NaN");
+    col.track("nil");
+    col.track("NaN");
     col.track("nan");
     col.track("null");
 
-    assertThat(col.getCounters().getCount(), is(9L));
-    assertThat(col.getCounters().getNullCount(), is(4L));
+    assertThat(col.getCounters().getCount(), is(10L));
+    assertThat(col.getCounters().getNullCount(), is(5L));
     assertThat(col.getCounters().getTrueCount(), is(1L));
     assertThat(col.getNumberTracker().getLongs().getCount(), is(0L));
     assertThat(col.getNumberTracker().getDoubles().getCount(), is(2L));

--- a/core/src/test/java/com/whylogs/core/DatasetProfileTest.java
+++ b/core/src/test/java/com/whylogs/core/DatasetProfileTest.java
@@ -1,15 +1,5 @@
 package com.whylogs.core;
 
-import com.google.common.collect.ImmutableMap;
-import lombok.val;
-import org.apache.commons.lang3.SerializationUtils;
-import org.testng.annotations.Test;
-
-import java.io.IOException;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.Collections;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.anEmptyMap;
@@ -18,6 +8,15 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+
+import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import lombok.val;
+import org.apache.commons.lang3.SerializationUtils;
+import org.testng.annotations.Test;
 
 public class DatasetProfileTest {
   @Test


### PR DESCRIPTION
Uses can customize values to be interpreted as null for the purposes of `ColumnProfile.getCounters().getNullCount()`.

The actual Java `null` value is always considered Null.  

A list of additional string values may also be counted as null by defining "NULL_STRINGS" environment variable, 
or by calling  the class method `ColumnProfile.initNullCheck(String nullSpec)`.

The value of "NULL_STRINGS" should be a comma-separated list of null strings, e.g.
```
export NULL_STRINGS="nil.NaN,nan,null"
```

This PR adds a unit test `column_NullTest_ShouldWork` to explicitly exercise this customized null check.

