### PR TITLE
Calculate quantiles when building NumberSummary

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -38,6 +38,7 @@ spotless {
 dependencies {
     api("org.slf4j:slf4j-api:1.7.27")
     api("org.apache.datasketches:datasketches-java:1.3.0-incubating")
+    api("org.apache.commons:commons-lang3:3.10")
     api("com.google.guava:guava:19.0")
     api("com.google.protobuf:protobuf-java:3.13.0")
     api("com.google.code.findbugs:jsr305:3.0.2")

--- a/core/src/main/java/com/whylogs/core/SummaryConverters.java
+++ b/core/src/main/java/com/whylogs/core/SummaryConverters.java
@@ -136,7 +136,9 @@ public class SummaryConverters {
     val qvals = numberTracker.getHistogram().getQuantiles(QUANTILES);
     val len = qvals.length;
     val boxedQvals = new Double[len];
-    for (int index = 0; index < qvals.length; index++) boxedQvals[index] = (double) (qvals[index]);
+    for (int index = 0; index < qvals.length; index++) {
+      boxedQvals[index] = (double) (qvals[index]);
+    }
 
     val quantileSummary =
         QuantileSummary.newBuilder()

--- a/core/src/main/java/com/whylogs/core/SummaryConverters.java
+++ b/core/src/main/java/com/whylogs/core/SummaryConverters.java
@@ -1,5 +1,7 @@
 package com.whylogs.core;
 
+import static org.apache.commons.lang3.ArrayUtils.toObject;
+
 import com.whylogs.core.message.FrequentNumbersSummary;
 import com.whylogs.core.message.FrequentStringsSummary;
 import com.whylogs.core.message.HistogramSummary;
@@ -22,8 +24,6 @@ import org.apache.datasketches.frequencies.ItemsSketch;
 import org.apache.datasketches.frequencies.ItemsSketch.Row;
 import org.apache.datasketches.kll.KllFloatsSketch;
 import org.apache.datasketches.theta.Union;
-import static org.apache.commons.lang3.ArrayUtils.toObject;
-
 
 public class SummaryConverters {
 
@@ -136,8 +136,7 @@ public class SummaryConverters {
     val qvals = numberTracker.getHistogram().getQuantiles(QUANTILES);
     val len = qvals.length;
     val boxedQvals = new Double[len];
-    for (int index = 0; index < qvals.length; index++)
-      boxedQvals[index] = (double) (qvals[index]);
+    for (int index = 0; index < qvals.length; index++) boxedQvals[index] = (double) (qvals[index]);
 
     val quantileSummary =
         QuantileSummary.newBuilder()

--- a/core/src/test/java/com/whylogs/core/ColumnProfileTest.java
+++ b/core/src/test/java/com/whylogs/core/ColumnProfileTest.java
@@ -11,7 +11,6 @@ import org.apache.datasketches.frequencies.ItemsSketch;
 import org.testng.annotations.Test;
 
 public class ColumnProfileTest {
-
   @Test
   public void column_BasicTracking_ShouldWork() {
     val col = new ColumnProfile("test");
@@ -156,4 +155,18 @@ public class ColumnProfileTest {
     assertThat(roundTrip.getColumnName(), is("test"));
     assertThat(roundTrip.getCounters().getCount(), is(2L));
   }
+
+  /**
+   *  Assert summary quantiles are not empty.
+   */
+  @Test
+  public void colums_Summary_Success() {
+    val col = new ColumnProfile("test");
+    col.track(1L);
+    col.track(1.0);
+
+    val quantiles = col.toColumnSummary().getNumberSummary().getQuantiles();
+    assertThat(quantiles.getQuantilesCount(), is(9));
+  }
+
 }

--- a/core/src/test/java/com/whylogs/core/ColumnProfileTest.java
+++ b/core/src/test/java/com/whylogs/core/ColumnProfileTest.java
@@ -156,9 +156,7 @@ public class ColumnProfileTest {
     assertThat(roundTrip.getCounters().getCount(), is(2L));
   }
 
-  /**
-   *  Assert summary quantiles are not empty.
-   */
+  /** Assert summary quantiles are not empty. */
   @Test
   public void colums_Summary_Success() {
     val col = new ColumnProfile("test");
@@ -168,5 +166,4 @@ public class ColumnProfileTest {
     val quantiles = col.toColumnSummary().getNumberSummary().getQuantiles();
     assertThat(quantiles.getQuantilesCount(), is(9));
   }
-
 }


### PR DESCRIPTION
```
QuantileSummary qs = colProfile.toColumnSummary().getNumberSummary().getQuantiles();
System.out.printf("JSON Quantiles %s\n", JsonFormat.printer().print(qs));
```

before:
```
JSON Quantiles {}
```

after:
```
JSON Quantiles {
  "quantiles": [0.0, 0.01, 0.05, 0.25, 0.5, 0.75, 0.95, 0.99, 1.0],
  "quantileValues": [-2354.131591796875, -868.7899780273438, -445.5729064941406, 211.17071533203125, 669.4403076171875, 1136.6209716796875, 1845.1197509765625, 2449.074462890625, 4070.94970703125]
}
```
