### PR TITLE
Limit string length

### DIFF
--- a/core/src/main/java/com/whylogs/core/ColumnProfile.java
+++ b/core/src/main/java/com/whylogs/core/ColumnProfile.java
@@ -109,7 +109,7 @@ public class ColumnProfile {
   }
 
   private void trackText(String text) {
-    if(text != null && text.length() > STRING_LENGTH_MAX) {
+    if (text != null && text.length() > STRING_LENGTH_MAX) {
       text = text.substring(0, STRING_LENGTH_MAX);
     }
     frequentItems.update(text);

--- a/core/src/main/java/com/whylogs/core/ColumnProfile.java
+++ b/core/src/main/java/com/whylogs/core/ColumnProfile.java
@@ -33,6 +33,7 @@ import org.apache.datasketches.memory.Memory;
 public class ColumnProfile {
   public static final int FREQUENT_MAX_LG_K = 7;
   private static final int CARDINALITY_LG_K = 12;
+  public static final int STRING_LENGTH_MAX = 256;
   private static volatile ImmutableSet<String> NULL_STR_ENVS;
 
   @NonNull private final String columnName;
@@ -108,6 +109,9 @@ public class ColumnProfile {
   }
 
   private void trackText(String text) {
+    if(text != null && text.length() > STRING_LENGTH_MAX) {
+      text = text.substring(0, STRING_LENGTH_MAX);
+    }
     frequentItems.update(text);
     cardinalityTracker.update(text);
   }

--- a/core/src/test/java/com/whylogs/core/ColumnProfileTest.java
+++ b/core/src/test/java/com/whylogs/core/ColumnProfileTest.java
@@ -104,6 +104,20 @@ public class ColumnProfileTest {
     merged.track("value");
   }
 
+
+  @Test
+  public void maxStringTruncation() {
+    val col = new ColumnProfile("test");
+    col.track("superlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstring");
+
+    val merged = col.merge(col);
+    val r = merged.getFrequentItems().getFrequentItems(1, ErrorType.NO_FALSE_POSITIVES);
+    assertThat("String should not exceed the limit", r[0].getItem().length() <= ColumnProfile.STRING_LENGTH_MAX);
+
+    // verify that the merged profile is updatable
+    merged.track("value");
+  }
+
   @Test
   public void profile_numeric_strings() {
     val col = new ColumnProfile("test");

--- a/core/src/test/java/com/whylogs/core/ColumnProfileTest.java
+++ b/core/src/test/java/com/whylogs/core/ColumnProfileTest.java
@@ -104,15 +104,17 @@ public class ColumnProfileTest {
     merged.track("value");
   }
 
-
   @Test
   public void maxStringTruncation() {
     val col = new ColumnProfile("test");
-    col.track("superlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstring");
+    col.track(
+        "superlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstringsuperlongstring");
 
     val merged = col.merge(col);
     val r = merged.getFrequentItems().getFrequentItems(1, ErrorType.NO_FALSE_POSITIVES);
-    assertThat("String should not exceed the limit", r[0].getItem().length() <= ColumnProfile.STRING_LENGTH_MAX);
+    assertThat(
+        "String should not exceed the limit",
+        r[0].getItem().length() <= ColumnProfile.STRING_LENGTH_MAX);
 
     // verify that the merged profile is updatable
     merged.track("value");


### PR DESCRIPTION
Adding a sanity check on string lengths so there's a reasonable maximum profile size limit per-column. This prevents abnormally large strings from affecting aggregation performance on the consuming end. 