### PR TITLE
Fix mismatch null count and schema count

### DIFF
--- a/core/src/main/java/com/whylogs/core/statistics/CountersTracker.java
+++ b/core/src/main/java/com/whylogs/core/statistics/CountersTracker.java
@@ -15,7 +15,6 @@ import lombok.val;
 public class CountersTracker {
   long count;
   long trueCount;
-  long nullCount;
 
   public void incrementCount() {
     count++;
@@ -25,21 +24,15 @@ public class CountersTracker {
     trueCount++;
   }
 
-  public void incrementNull() {
-    nullCount++;
-  }
-
   public void add(CountersTracker other) {
     this.count += other.count;
     this.trueCount += other.trueCount;
-    this.nullCount += other.nullCount;
   }
 
   public CountersTracker merge(CountersTracker other) {
     val result = new CountersTracker();
     result.count = this.count + other.count;
     result.trueCount = this.trueCount + other.trueCount;
-    result.nullCount = this.nullCount + other.nullCount;
 
     return result;
   }
@@ -51,20 +44,13 @@ public class CountersTracker {
       countersBuilder.setTrueCount(Int64Value.of(trueCount));
     }
 
-    if (nullCount > 0) {
-      countersBuilder.setNullCount(Int64Value.of(nullCount));
-    }
-
     return countersBuilder;
   }
 
   public static CountersTracker fromProtobuf(Counters message) {
     val tracker = new CountersTracker();
     tracker.count = message.getCount();
-    tracker.trueCount =
-        Optional.ofNullable(message.getTrueCount()).map(Int64Value::getValue).orElse(0L);
-    tracker.nullCount =
-        Optional.ofNullable(message.getNullCount()).map(Int64Value::getValue).orElse(0L);
+    tracker.trueCount = Optional.of(message.getTrueCount()).map(Int64Value::getValue).orElse(0L);
 
     return tracker;
   }

--- a/core/src/main/java/com/whylogs/core/types/TypedDataConverter.java
+++ b/core/src/main/java/com/whylogs/core/types/TypedDataConverter.java
@@ -34,28 +34,12 @@ public class TypedDataConverter {
       return null;
     }
 
+    if (data instanceof TypedData) {
+      return (TypedData) data;
+    }
+
     if (data instanceof String) {
-      val strData = (String) data;
-
-      INTEGRAL_MATCHER.get().reset(strData);
-      if (INTEGRAL_MATCHER.get().matches()) {
-        val trimmedText = EMPTY_SPACES_REMOVER.get().reset(strData).replaceAll("");
-        return TypedData.integralValue(Long.parseLong(trimmedText));
-      }
-
-      FRACTIONAL_MATCHER.get().reset(strData);
-      if (FRACTIONAL_MATCHER.get().matches()) {
-        val trimmedText = EMPTY_SPACES_REMOVER.get().reset(strData).replaceAll("");
-        return TypedData.fractionalValue(Double.parseDouble(trimmedText));
-      }
-
-      BOOLEAN_MATCHER.get().reset(strData);
-      if (BOOLEAN_MATCHER.get().matches()) {
-        val trimmedText = EMPTY_SPACES_REMOVER.get().reset(strData).replaceAll("");
-        return TypedData.booleanValue(Boolean.parseBoolean(trimmedText));
-      }
-
-      return TypedData.stringValue(strData);
+      return getTypedStringData((String) data);
     }
 
     if (data instanceof Double || data instanceof Float) {
@@ -73,5 +57,29 @@ public class TypedDataConverter {
     }
 
     return TypedData.unknownValue();
+  }
+
+  private TypedData getTypedStringData(String data) {
+    if (System.getenv().get("WHYLOGS_ENABLE_STRING_MATCHING") != null) {
+      INTEGRAL_MATCHER.get().reset(data);
+      if (INTEGRAL_MATCHER.get().matches()) {
+        val trimmedText = EMPTY_SPACES_REMOVER.get().reset(data).replaceAll("");
+        return TypedData.integralValue(Long.parseLong(trimmedText));
+      }
+
+      FRACTIONAL_MATCHER.get().reset(data);
+      if (FRACTIONAL_MATCHER.get().matches()) {
+        val trimmedText = EMPTY_SPACES_REMOVER.get().reset(data).replaceAll("");
+        return TypedData.fractionalValue(Double.parseDouble(trimmedText));
+      }
+
+      BOOLEAN_MATCHER.get().reset(data);
+      if (BOOLEAN_MATCHER.get().matches()) {
+        val trimmedText = EMPTY_SPACES_REMOVER.get().reset(data).replaceAll("");
+        return TypedData.booleanValue(Boolean.parseBoolean(trimmedText));
+      }
+    }
+
+    return TypedData.stringValue(data);
   }
 }

--- a/core/src/test/java/com/whylogs/core/statistics/CountersTrackerTest.java
+++ b/core/src/test/java/com/whylogs/core/statistics/CountersTrackerTest.java
@@ -17,17 +17,12 @@ public class CountersTrackerTest {
     original.incrementCount();
 
     assertThat(original.getCount(), is(2L));
-    assertThat(original.getNullCount(), is(0L));
     assertThat(original.getTrueCount(), is(0L));
-
-    original.incrementNull();
-    assertThat(original.getNullCount(), is(1L));
 
     original.incrementTrue();
     assertThat(original.getTrueCount(), is(1L));
 
     val roundtrip = CountersTracker.fromProtobuf(original.toProtobuf().build());
-    assertThat(roundtrip.getNullCount(), is(1L));
     assertThat(roundtrip.getTrueCount(), is(1L));
     assertThat(roundtrip.getCount(), is(2L));
   }
@@ -37,23 +32,17 @@ public class CountersTrackerTest {
     val first = new CountersTracker();
     first.incrementCount();
     first.incrementCount();
-    first.incrementNull();
-    first.incrementNull();
-    first.incrementNull();
     first.incrementTrue();
 
     assertThat(first.getCount(), is(2L));
-    assertThat(first.getNullCount(), is(3L));
     assertThat(first.getTrueCount(), is(1L));
 
     val second = new CountersTracker();
     second.incrementCount();
-    second.incrementNull();
 
     val merge1 = first.merge(second);
 
     assertThat(merge1.getCount(), is(3L));
-    assertThat(merge1.getNullCount(), is(4L));
     assertThat(merge1.getTrueCount(), is(1L));
 
     // should be associative

--- a/core/src/test/java/com/whylogs/core/statistics/SchemaTrackerTest.java
+++ b/core/src/test/java/com/whylogs/core/statistics/SchemaTrackerTest.java
@@ -138,7 +138,7 @@ public class SchemaTrackerTest {
     trackAFewTimes(first, Type.BOOLEAN, 20);
     trackAFewTimes(first, Type.UNKNOWN, 20);
 
-    final val merged = first.merge(second);
+    val merged = first.merge(second);
     assertThat(merged.getCount(Type.INTEGRAL), is(30L));
     assertThat(merged.getCount(Type.FRACTIONAL), is(30L));
     assertThat(merged.getCount(Type.BOOLEAN), is(30L));

--- a/spark/src/test/scala/com/whylogs/spark/WhyLogsTest.scala
+++ b/spark/src/test/scala/com/whylogs/spark/WhyLogsTest.scala
@@ -6,6 +6,7 @@ import java.sql.Timestamp
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import com.whylogs.core.DatasetProfile
+import com.whylogs.core.message.InferredType
 import com.whylogs.spark.WhyLogs.ProfiledDataFrame
 import org.apache.commons.lang3.RandomUtils
 import org.apache.spark.sql.{Row, SaveMode}
@@ -125,6 +126,6 @@ class WhyLogsTest extends AnyFunSuite with SharedSparkContext {
     val bytes = res.collect()(0).getAs[Array[Byte]](0)
     val dp = DatasetProfile.parse(new ByteArrayInputStream(bytes))
 
-    assert(dp.getColumns.get("age").getCounters.getNullCount == 1)
+    assert(dp.getColumns.get("age").getSchemaTracker.getTypeCounts.get(InferredType.Type.NULL) == 1)
   }
 }


### PR DESCRIPTION
Backwards compatibility: summary still has the null count under "counters"

For existing profiles, we can workaround by adding the two values together.
For new profiles after this PR, the null_count will always come from SchemaTracker and not Counters

Also, turn off SCHEMA detection by default

Reference: https://github.com/whylabs/whylogs/pull/234