### PR TITLE
Use the new upload url based api for logging

### DIFF
--- a/spark-bundle/build.gradle.kts
+++ b/spark-bundle/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
     // we only depends on the output of the whylogs-spark components
     // we don't want to pull in Spark dependencies here
     implementation(project(":spark", "jar"))
-    implementation("ai.whylabs:whylabs-api-client:0.1.2")
+    implementation("ai.whylabs:whylabs-api-client:0.1.4")
 }
 
 // Do not build the jar for this package

--- a/spark/build.gradle.kts
+++ b/spark/build.gradle.kts
@@ -78,7 +78,7 @@ dependencies {
     implementation(project(":core"))
 
     // Songbird
-    implementation("ai.whylabs:whylabs-api-client:0.1.2")
+    implementation("ai.whylabs:whylabs-api-client:0.1.4")
     implementation("com.squareup.okhttp3:okhttp:4.9.1")
 
     // lombok support


### PR DESCRIPTION
Our original upload api has the client uploading directly to our rest
service. Now we return upload urls that the client should use to upload
directly, rather than proxying through our servers.