### PR TITLE
add Getters to all model metrics fields.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.2-b7
+current_version = 0.1.3-b1
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "ai.whylabs"
-version = "0.1.3"
+version = "0.1.3-b1"
 //version = "0.1.3-${project.properties.getOrDefault("versionType", "SNAPSHOT")}"
 extra["isReleaseVersion"] = !version.toString().endsWith("SNAPSHOT")
 

--- a/core/src/main/java/com/whylogs/core/metrics/ModelMetrics.java
+++ b/core/src/main/java/com/whylogs/core/metrics/ModelMetrics.java
@@ -11,7 +11,7 @@ import lombok.val;
 
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class ModelMetrics {
-  private final ModelType modelType;
+  @Getter private final ModelType modelType;
   @Getter private final ScoreMatrix scoreMatrix;
   @Getter private final RegressionMetrics regressionMetrics;
 
@@ -85,21 +85,8 @@ public class ModelMetrics {
     if (msg == null || msg.getSerializedSize() == 0) {
       return null;
     }
-    switch (msg.getModelType()) {
-      case CLASSIFICATION:
-        val scoreMatrix = ScoreMatrix.fromProtobuf(msg.getScoreMatrix());
-        if (scoreMatrix == null) {
-          return null;
-        }
-        return new ModelMetrics(msg.getModelType(), scoreMatrix, null);
-      case REGRESSION:
-        val regressionMetrics = RegressionMetrics.fromProtobuf(msg.getRegressionMetrics());
-        if (regressionMetrics == null) {
-          return null;
-        }
-        return new ModelMetrics(msg.getModelType(), null, regressionMetrics);
-      default:
-        throw new IllegalArgumentException("Unsupported model type: " + msg.getModelType());
-    }
+    val scoreMatrix = ScoreMatrix.fromProtobuf(msg.getScoreMatrix());
+    val regressionMetrics = RegressionMetrics.fromProtobuf(msg.getRegressionMetrics());
+    return new ModelMetrics(msg.getModelType(), scoreMatrix, regressionMetrics);
   }
 }

--- a/core/src/main/java/com/whylogs/core/metrics/ScoreMatrix.java
+++ b/core/src/main/java/com/whylogs/core/metrics/ScoreMatrix.java
@@ -17,11 +17,12 @@ import lombok.val;
 
 @Slf4j
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
 public class ScoreMatrix {
   private List<String> labels;
-  @Getter private final String predictionField;
-  @Getter private final String targetField;
-  @Getter private final String scoreField;
+  private final String predictionField;
+  private final String targetField;
+  private final String scoreField;
   private NumberTracker[][] values;
 
   public ScoreMatrix(String predictionField, String targetField, String scoreField) {


### PR DESCRIPTION
- Add Getters to ModelMetrics and ScoreMatrix classes.  These are used by druid model metrics extensions.
- Make ModelMetrics.fromProtobuf match python functionality.
- Bump whylogs-java version frin '0.1.3' to '0.1.3-b1'