### PR TITLE
update StringTracker with new fields from python library

### DIFF
--- a/core/src/main/java/com/whylogs/core/ColumnProfile.java
+++ b/core/src/main/java/com/whylogs/core/ColumnProfile.java
@@ -48,7 +48,6 @@ public class ColumnProfile {
   @NonNull private final ImmutableSet<String> nullStrs;
   private final StringTracker stringTracker;
 
-
   static ImmutableSet<String> nullStrsFromEnv() {
     if (ColumnProfile.NULL_STR_ENVS == null) {
       val nullSpec = System.getenv("NULL_STRINGS");
@@ -220,17 +219,19 @@ public class ColumnProfile {
 
   public static ColumnProfile fromProtobuf(ColumnMessage message) {
 
-    val builder = ColumnProfile.builder()
-        .setColumnName(message.getName())
-        .setCounters(CountersTracker.fromProtobuf(message.getCounters()))
-        .setSchemaTracker(
-            SchemaTracker.fromProtobuf(
-                message.getSchema(), message.getCounters().getNullCount().getValue()))
-        .setNumberTracker(NumberTracker.fromProtobuf(message.getNumbers()))
-        .setCardinalityTracker(
-            HllSketch.heapify(message.getCardinalityTracker().getSketch().toByteArray()))
-        .setFrequentItems(FrequentStringsSketch.deserialize(message.getFrequentItems().getSketch()))
-        .setNullStrs(ColumnProfile.nullStrsFromEnv());
+    val builder =
+        ColumnProfile.builder()
+            .setColumnName(message.getName())
+            .setCounters(CountersTracker.fromProtobuf(message.getCounters()))
+            .setSchemaTracker(
+                SchemaTracker.fromProtobuf(
+                    message.getSchema(), message.getCounters().getNullCount().getValue()))
+            .setNumberTracker(NumberTracker.fromProtobuf(message.getNumbers()))
+            .setCardinalityTracker(
+                HllSketch.heapify(message.getCardinalityTracker().getSketch().toByteArray()))
+            .setFrequentItems(
+                FrequentStringsSketch.deserialize(message.getFrequentItems().getSketch()))
+            .setNullStrs(ColumnProfile.nullStrsFromEnv());
 
     // backward compatibility - only decode these messages if they exist
     if (message.getStrings().toByteArray().length > 0) {

--- a/core/src/main/java/com/whylogs/core/SummaryConverters.java
+++ b/core/src/main/java/com/whylogs/core/SummaryConverters.java
@@ -40,13 +40,17 @@ public class SummaryConverters {
     if (tracker == null) {
       return null;
     }
-
     if (tracker.getCount() == 0) {
       return null;
     }
 
     val uniqueCount = fromSketch(tracker.getThetaSketch());
-    val builder = StringsSummary.newBuilder().setUniqueCount(uniqueCount);
+    val builder =
+        StringsSummary.newBuilder()
+            .setUniqueCount(uniqueCount)
+            .setLength(fromNumberTracker(tracker.getLength()))
+            .setTokenLength(fromNumberTracker(tracker.getTokenLength()))
+            .setCharPosTracker(tracker.getCharPosTracker().toSummary());
 
     // TODO: make this value (100) configurable
     if (uniqueCount.getEstimate() < 100) {

--- a/core/src/main/java/com/whylogs/core/statistics/datatypes/CharPosTracker.java
+++ b/core/src/main/java/com/whylogs/core/statistics/datatypes/CharPosTracker.java
@@ -1,0 +1,180 @@
+package com.whylogs.core.statistics.datatypes;
+
+import static com.google.common.collect.Maps.newHashMap;
+import static com.google.common.collect.Sets.newHashSet;
+
+import com.google.common.base.Joiner;
+import com.whylogs.core.SummaryConverters;
+import com.whylogs.core.message.CharPosMessage;
+import com.whylogs.core.message.CharPosSummary;
+import com.whylogs.core.message.NumberSummary;
+import com.whylogs.core.statistics.NumberTracker;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+
+@Slf4j
+@AllArgsConstructor
+public class CharPosTracker {
+  private Set<Character> characterList;
+  @Getter private final Map<Character, NumberTracker> charPosMap;
+
+  CharPosTracker(Set<Character> characterList) {
+    this.characterList = characterList;
+    this.charPosMap = newHashMap();
+  }
+
+  CharPosTracker(String charString, Map<Character, NumberTracker> charPosMap) {
+    this.characterList =
+        charString
+            .chars()
+            .mapToObj(chr -> (char) chr) // autoboxed to Character
+            .collect(Collectors.toSet());
+    this.charPosMap = charPosMap;
+  }
+
+  CharPosTracker(String charString) {
+    this(
+        charString
+            .chars()
+            .mapToObj(chr -> (char) chr) // autoboxed to Character
+            .collect(Collectors.toSet()));
+  }
+
+  CharPosTracker() {
+    this("abcdefghijklmnopqrstuvwzyz0123456789-@!#$%^&*()[]{}");
+  }
+
+  private void update(int idx, char c) {
+    // TODO synchronize access
+    if (characterList != null && characterList.contains(c)) {
+      if (!charPosMap.containsKey(c)) {
+        charPosMap.put(c, new NumberTracker());
+      }
+      charPosMap.get(c).track(idx);
+    } else {
+      // TODO self.char_pos_map["NITL"].track(indx)
+      if (!charPosMap.containsKey((char) 0)) {
+        charPosMap.put((char) 0, new NumberTracker());
+      }
+      charPosMap.get((char) 0).track(idx);
+    }
+  }
+
+  private void update(int idx, int codePoint) {
+    val chars = Character.toChars(codePoint);
+    if (chars.length == 1) {
+      update(idx, Character.toLowerCase(chars[0]));
+    } else {
+      // TODO synchronize access
+      if (!charPosMap.containsKey((char) 0)) {
+        charPosMap.put((char) 0, new NumberTracker());
+      }
+      charPosMap.get((char) 0).track(idx);
+    }
+  }
+
+  public void update(String value) {
+    AtomicInteger i = new AtomicInteger();
+    value.codePoints().forEach(cp -> update(i.getAndIncrement(), cp));
+  }
+
+  public void update(String value, String charString) {
+    if (charString != null) {
+      val newSet =
+          charString
+              .chars()
+              .mapToObj(chr -> (char) chr) // autoboxed to Character
+              .collect(Collectors.toSet());
+      if (!characterList.equals(newSet)) {
+        if (!charPosMap.isEmpty()) {
+          log.warn(
+              "Changing character list, a non-empty character position tracker is being reset to remove ambiguities");
+        }
+        characterList = newSet;
+        charPosMap.clear();
+      }
+    }
+
+    AtomicInteger i = new AtomicInteger();
+    value.codePoints().forEach(cp -> update(i.getAndIncrement(), cp));
+  }
+
+  public CharPosTracker merge(CharPosTracker other) {
+    if (characterList != other.characterList && (charPosMap == null || other.charPosMap == null)) {
+      log.error("Merging two non-empty Character position tracker with different character lists");
+    }
+
+    Set<Character> newCharacterList = newHashSet();
+    newCharacterList.addAll(characterList);
+    newCharacterList.addAll(other.characterList);
+
+    // merge
+    Map<Character, NumberTracker> newCharPosMap = newHashMap();
+    newCharacterList.forEach(
+        c -> {
+          val tracker = charPosMap.get(c);
+          val otherTracker = other.charPosMap.get(c);
+
+          if (tracker != null && otherTracker != null) {
+            newCharPosMap.put(c, tracker.merge(otherTracker));
+          } else if (tracker != null) {
+            newCharPosMap.put(c, tracker);
+          } else if (otherTracker != null) {
+            newCharPosMap.put(c, otherTracker);
+          }
+        });
+
+    // merge not in the list
+    val nitlTracker = charPosMap.get((char) 0);
+    val otherNitlTracker = other.charPosMap.get((char) 0);
+
+    if (nitlTracker != null && otherNitlTracker != null) {
+      newCharPosMap.put((char) 0, nitlTracker.merge(otherNitlTracker));
+    } else if (nitlTracker != null) {
+      newCharPosMap.put((char) 0, nitlTracker);
+    } else if (otherNitlTracker != null) {
+      newCharPosMap.put((char) 0, otherNitlTracker);
+    }
+    return new CharPosTracker(newCharacterList, newCharPosMap);
+  }
+
+  public CharPosMessage toProtobuf() {
+    val mapMsg =
+        charPosMap.entrySet().stream()
+            .collect(
+                Collectors.toMap(
+                    e -> e.getKey().toString(), e -> e.getValue().toProtobuf().build()));
+    return CharPosMessage.newBuilder()
+        .putAllCharPosMap(mapMsg)
+        // TODO changes order of characters in characterlist string
+        .setCharList(Joiner.on("").join(characterList))
+        .build();
+  }
+
+  public static CharPosTracker fromProtobuf(CharPosMessage msg) {
+    Map<Character, NumberTracker> map = newHashMap();
+    msg.getCharPosMapMap().forEach((k, v) -> map.put(k.charAt(0), NumberTracker.fromProtobuf(v)));
+    return new CharPosTracker(msg.getCharList(), map);
+  }
+
+  public CharPosSummary toSummary() {
+    Map<String, NumberSummary> map = newHashMap();
+    val nullChar = new Character((char) 0);
+    charPosMap.forEach(
+        (k, v) ->
+            map.put(
+                k.equals(nullChar) ? "NITL" : k.toString(),
+                SummaryConverters.fromNumberTracker(v)));
+
+    return CharPosSummary.newBuilder()
+        .setCharacterList(Joiner.on("").join(characterList))
+        .putAllCharPosMap(map)
+        .build();
+  }
+}

--- a/core/src/main/java/com/whylogs/core/statistics/datatypes/StringTracker.java
+++ b/core/src/main/java/com/whylogs/core/statistics/datatypes/StringTracker.java
@@ -145,13 +145,17 @@ public final class StringTracker {
   }
 
   public StringsMessage.Builder toProtobuf() {
-    return StringsMessage.newBuilder()
-        .setCount(count)
-        .setItems(ByteString.copyFrom(items.toByteArray(ARRAY_OF_STRINGS_SER_DE)))
-        .setCompactTheta(ThetaSketch.serialize(thetaSketch))
-        .setLength(length.toProtobuf())
-        .setTokenLength(tokenLength.toProtobuf())
-        .setCharPosTracker(charPosTracker.toProtobuf());
+    val builder =
+        StringsMessage.newBuilder()
+            .setCount(count)
+            .setCompactTheta(ThetaSketch.serialize(thetaSketch))
+            .setLength(length.toProtobuf())
+            .setTokenLength(tokenLength.toProtobuf())
+            .setCharPosTracker(charPosTracker.toProtobuf());
+    if (items != null) {
+      builder.setItems(ByteString.copyFrom(items.toByteArray(ARRAY_OF_STRINGS_SER_DE)));
+    }
+    return builder;
   }
 
   public static StringTracker fromProtobuf(StringsMessage message) {

--- a/core/src/main/java/com/whylogs/core/statistics/datatypes/StringTracker.java
+++ b/core/src/main/java/com/whylogs/core/statistics/datatypes/StringTracker.java
@@ -2,7 +2,11 @@ package com.whylogs.core.statistics.datatypes;
 
 import com.google.protobuf.ByteString;
 import com.whylogs.core.message.StringsMessage;
+import com.whylogs.core.statistics.NumberTracker;
 import com.whylogs.core.utils.sketches.ThetaSketch;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,6 +22,8 @@ import org.apache.datasketches.theta.Union;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public final class StringTracker {
+  public static Function<String, List<String>> TOKENIZER = str -> Arrays.asList(str.split(" "));
+
   public static final ArrayOfStringsSerDe ARRAY_OF_STRINGS_SER_DE = new ArrayOfStringsSerDe();
   // be careful to not use 32 here - somehow the sketches are empty
   public static final int MAX_FREQUENT_ITEM_SIZE = 128;
@@ -27,14 +33,26 @@ public final class StringTracker {
   // sketches
   private final ItemsSketch<String> items;
   private final Union thetaSketch;
+  private final NumberTracker length;
+  private final NumberTracker tokenLength;
+  private final CharPosTracker charPosTracker;
+  @Builder.Default private Function<String, List<String>> tokenizer = TOKENIZER;
 
   public StringTracker() {
     this.count = 0L;
     this.items = new ItemsSketch<>(MAX_FREQUENT_ITEM_SIZE); // TODO: make this value configurable
     this.thetaSketch = Union.builder().buildUnion();
+    this.length = new NumberTracker();
+    this.tokenLength = new NumberTracker();
+    this.charPosTracker = new CharPosTracker();
+    this.tokenizer = TOKENIZER;
   }
 
   public void update(String value) {
+    update(value, null);
+  }
+
+  public void update(String value, String charString) {
     if (value == null) {
       return;
     }
@@ -42,6 +60,17 @@ public final class StringTracker {
     count++;
     thetaSketch.update(value);
     items.update(value);
+    charPosTracker.update(value, charString);
+    length.track(value.length());
+    // TODO allow updates of tokenizer
+    tokenLength.track(tokenizer.apply(value).size());
+  }
+
+  public void update(String value, String charString, Function<String, List<String>> tokenizer) {
+    if (tokenizer != null) {
+      this.tokenizer = tokenizer;
+    }
+    update(value, charString);
   }
 
   /**
@@ -59,24 +88,51 @@ public final class StringTracker {
     thetaUnion.update(this.thetaSketch.getResult());
     thetaUnion.update(other.thetaSketch.getResult());
 
-    return new StringTracker(this.count + other.count, itemsCopy, thetaUnion);
+    val newLength = length.merge(other.length);
+    val newTokenLength = tokenLength.merge(other.tokenLength);
+    val newCharPostTracker = charPosTracker.merge(other.charPosTracker);
+
+    return StringTracker.builder()
+        .count(this.count + other.count)
+        .items(itemsCopy)
+        .thetaSketch(thetaUnion)
+        .length(newLength)
+        .tokenLength(newTokenLength)
+        .charPosTracker(newCharPostTracker)
+        .build();
   }
 
   public StringsMessage.Builder toProtobuf() {
     return StringsMessage.newBuilder()
         .setCount(count)
         .setItems(ByteString.copyFrom(items.toByteArray(ARRAY_OF_STRINGS_SER_DE)))
-        .setCompactTheta(ThetaSketch.serialize(thetaSketch));
+        .setCompactTheta(ThetaSketch.serialize(thetaSketch))
+        .setLength(length.toProtobuf())
+        .setTokenLength(tokenLength.toProtobuf())
+        .setCharPosTracker(charPosTracker.toProtobuf());
   }
 
   public static StringTracker fromProtobuf(StringsMessage message) {
-    val iMem = Memory.wrap(message.getItems().toByteArray());
-    val items = ItemsSketch.getInstance(iMem, ARRAY_OF_STRINGS_SER_DE);
+    ItemsSketch<String> items = null;
+    val ba = message.getItems().toByteArray();
+    if (ba.length > 8) {
+      val iMem = Memory.wrap(ba);
+      items = ItemsSketch.getInstance(iMem, ARRAY_OF_STRINGS_SER_DE);
+    }
 
-    return StringTracker.builder()
-        .count(message.getCount())
-        .items(items)
-        .thetaSketch(ThetaSketch.deserialize(message.getCompactTheta()))
-        .build();
+    val builder =
+        StringTracker.builder()
+            .count(message.getCount())
+            .items(items)
+            .thetaSketch(ThetaSketch.deserialize(message.getCompactTheta()));
+
+    // backward compatibility - only decode these messages if they exist
+    if (message.getLength().toByteArray().length > 0) {
+      builder
+          .length(NumberTracker.fromProtobuf(message.getLength()))
+          .tokenLength(NumberTracker.fromProtobuf(message.getTokenLength()))
+          .charPosTracker(CharPosTracker.fromProtobuf(message.getCharPosTracker()));
+    }
+    return builder.build();
   }
 }

--- a/core/src/main/java/com/whylogs/core/statistics/datatypes/StringTracker.java
+++ b/core/src/main/java/com/whylogs/core/statistics/datatypes/StringTracker.java
@@ -116,9 +116,15 @@ public final class StringTracker {
    * @return a new StringTracker object
    */
   public StringTracker merge(StringTracker other) {
-    val bytes = this.items.toByteArray(ARRAY_OF_STRINGS_SER_DE);
-    val itemsCopy = ItemsSketch.getInstance(WritableMemory.wrap(bytes), ARRAY_OF_STRINGS_SER_DE);
-    itemsCopy.merge(other.items);
+    ItemsSketch<String> itemsCopy = null;
+    if (this.items != null) {
+      val bytes = this.items.toByteArray(ARRAY_OF_STRINGS_SER_DE);
+      itemsCopy = ItemsSketch.getInstance(WritableMemory.wrap(bytes), ARRAY_OF_STRINGS_SER_DE);
+      itemsCopy.merge(other.items);
+    } else if (other.items != null) {
+      val bytes = other.items.toByteArray(ARRAY_OF_STRINGS_SER_DE);
+      itemsCopy = ItemsSketch.getInstance(WritableMemory.wrap(bytes), ARRAY_OF_STRINGS_SER_DE);
+    }
 
     val thetaUnion = Union.builder().buildUnion();
     thetaUnion.update(this.thetaSketch.getResult());

--- a/core/src/main/java/com/whylogs/core/statistics/datatypes/StringTracker.java
+++ b/core/src/main/java/com/whylogs/core/statistics/datatypes/StringTracker.java
@@ -48,10 +48,33 @@ public final class StringTracker {
     this.tokenizer = TOKENIZER;
   }
 
+  /**
+   * Track statistical properties of characters in a string.
+   *
+   * <p>`value` is a Unicode string. `value` is tokenized and tokens are passed to CharPosTracker
+   * for tracking of position and frequency of unicode codepoints in the token.
+   *
+   * <p>Variants of this function signature allow modification of tokenizer and tracked character
+   * set during updates. Unless overridden by one of the other update routines, uses a tokenizer
+   * that breaks strings at spaces, and tracks alphanumeric lowercase characters.
+   *
+   * @param value string
+   */
   public void update(String value) {
     update(value, null);
   }
 
+  /**
+   * Track statistical properties of just the characters from a given character set.
+   *
+   * <p>`value` is tokenized, and position and frequency of unicode codepoints within tokens are
+   * tracked if they appear in `charString`. If set, `charString` will be applied to subsequent
+   * calls to update, overriding the default character set.
+   *
+   * @param value string Unicode string to be tracked
+   * @param charString string - Set of characters that should be tracked. all others will be tracked
+   *     as 'NITL'
+   */
   public void update(String value, String charString) {
     if (value == null) {
       return;
@@ -66,6 +89,19 @@ public final class StringTracker {
     tokenLength.track(tokenizer.apply(value).size());
   }
 
+  /**
+   * Track statistical properties of a string. Allows control over characters to be tracked and
+   * tokenizer function.
+   *
+   * <p>`value` is tokenized according to `tokenizer`. Position and frequency of unicode codepoints
+   * within tokens are tracked if they appear in `charString`. If set, `charString` and/or
+   * `tokenizer` will be used for subsequent calls to `update`
+   *
+   * @param value string
+   * @param charString string - Set of characters that should be tracked. all others will be tracked
+   *     as 'NITL'
+   * @param tokenizer function taking string and returning list of strings.
+   */
   public void update(String value, String charString, Function<String, List<String>> tokenizer) {
     if (tokenizer != null) {
       this.tokenizer = tokenizer;

--- a/core/src/main/java/com/whylogs/core/statistics/datatypes/StringTracker.java
+++ b/core/src/main/java/com/whylogs/core/statistics/datatypes/StringTracker.java
@@ -173,7 +173,8 @@ public final class StringTracker {
             .thetaSketch(ThetaSketch.deserialize(message.getCompactTheta()));
 
     // backward compatibility - only decode these messages if they exist
-    if (message.getLength().toByteArray().length > 0) {
+    // older profiles written by python library may not have these fields.
+    if (message.hasLength()) {
       builder
           .length(NumberTracker.fromProtobuf(message.getLength()))
           .tokenLength(NumberTracker.fromProtobuf(message.getTokenLength()))

--- a/core/src/test/java/com/whylogs/core/statistics/datatypes/StringTrackerTest.java
+++ b/core/src/test/java/com/whylogs/core/statistics/datatypes/StringTrackerTest.java
@@ -2,11 +2,47 @@ package com.whylogs.core.statistics.datatypes;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertEquals;
 
+import com.google.common.collect.ImmutableSet;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import lombok.val;
 import org.testng.annotations.Test;
 
 public class StringTrackerTest {
+  @Test
+  public void stringTracker_characterPosTracking() {
+    /* based on python test_character_pos_tracker() */
+
+    val tracker = new StringTracker();
+    val data = Arrays.asList("abc abc", "93341-1", "912254", null);
+    val noNulls = data.stream().filter(Objects::nonNull).collect(Collectors.toList());
+    val count = noNulls.size();
+    val n_unique = ImmutableSet.copyOf(noNulls).size();
+
+    data.forEach(tracker::update);
+
+    assertThat(tracker.getItems().getNumActiveItems(), is(n_unique));
+    assertThat(tracker.getItems().getStreamLength(), is((long) count));
+
+    assertEquals(tracker.getLength().getLongs().getMean(), 6.666, 0.001);
+    assertEquals(tracker.getTokenLength().getLongs().getMean(), 1.333, 0.001);
+    assertEquals(tracker.getThetaSketch().getResult().getEstimate(), n_unique, 0.0);
+
+    assertThat(tracker.getCharPosTracker(), is(notNullValue()));
+    assertThat(tracker.getCount(), is((long) count));
+    assertThat(
+        tracker.getCharPosTracker().getCharPosMap().get('a').getHistogram().getMinValue(),
+        is(0.0F));
+    assertThat(
+        tracker.getCharPosTracker().getCharPosMap().get('a').getLongs().getCount(), is((long) 2));
+    assertThat(
+        tracker.getCharPosTracker().getCharPosMap().get('-').getHistogram().getMinValue(),
+        is(5.0F));
+  }
 
   @Test
   public void stringTracker_BasicStringTracking() {
@@ -22,21 +58,67 @@ public class StringTrackerTest {
 
   @Test
   public void stringTracker_Merge() {
-    val tracker = new StringTracker();
-    tracker.update("foo1");
-    tracker.update("foo2");
-    tracker.update("foo3");
+    val x = new StringTracker();
+    val y = new StringTracker();
+    val data = Arrays.asList("abc abc", "93341-1", "912254", "bac tralalala");
+    val data2 =
+        Arrays.asList(
+            "geometric inference ",
+            "93341-1",
+            "912254",
+            "bac tralalala",
+            "😀 this is a sale! a ❄️ sale!",
+            "this is a long sentence that ends in an A",
+            null);
+    data.forEach(x::update);
+    data2.forEach(y::update);
 
-    assertThat(tracker.getCount(), is(3L));
-    assertThat(tracker.getItems().getNumActiveItems(), is(3));
+    assertThat(x.getCharPosTracker().getCharPosMap().get((char) 0).getLongs().getCount(), is(2L));
+    assertThat(
+        x.getCharPosTracker().getCharPosMap().get('a').getHistogram().getMaxValue(), is(12F));
+    assertThat(y.getCharPosTracker().getCharPosMap().get((char) 0).getLongs().getCount(), is(22L));
+    assertThat(
+        y.getCharPosTracker().getCharPosMap().get('a').getHistogram().getMaxValue(), is(40F));
 
-    val merged = tracker.merge(tracker);
-    assertThat(merged.getCount(), is(6L));
-    assertThat(merged.getItems().getNumActiveItems(), is(3));
+    val z = x.merge(y);
+    assertThat(
+        z.getCharPosTracker().getCharPosMap().get('a').getHistogram().getMaxValue(), is(40F));
+    assertThat(z.getCharPosTracker().getCharPosMap().get((char) 0).getLongs().getCount(), is(24L));
+
+    assertThat(z.getCount(), is(10L));
+    assertThat(z.getItems().getNumActiveItems(), is(7));
 
     // verify we can serialize the merge object
-    val msg = merged.toProtobuf().build();
+    val msg = z.toProtobuf().build();
     StringTracker.fromProtobuf(msg);
+  }
+
+  @Test
+  public void stringTracker_MergeCharacterLists() {
+    val x = new StringTracker();
+    val y = new StringTracker();
+    val data = Arrays.asList("abc abc", "93341-1", "912254", "bac tralalala");
+    val data2 =
+        Arrays.asList(
+            "geometric inference ",
+            "93341-1",
+            "912254",
+            "bac tralalala",
+            "😀 this is a sale! a ❄️ sale!",
+            "this is a long sentence that ends in an A",
+            null);
+    data.forEach(d -> x.update(d, "ab"));
+    data2.forEach(d -> y.update(d, "a"));
+    assertThat(x.getCharPosTracker().getCharPosMap().get((char) 0).getLongs().getCount(), is(23L));
+    assertThat(
+        x.getCharPosTracker().getCharPosMap().get('a').getHistogram().getMaxValue(), is(12F));
+    assertThat(y.getCharPosTracker().getCharPosMap().get((char) 0).getLongs().getCount(), is(102L));
+    assertThat(
+        y.getCharPosTracker().getCharPosMap().get('a').getHistogram().getMaxValue(), is(40F));
+
+    val z = x.merge(y);
+    assertThat(
+        z.getCharPosTracker().getCharPosMap().get('a').getHistogram().getMaxValue(), is(40F));
   }
 
   @Test


### PR DESCRIPTION
Add StringTracker to ColumnProfile.  StringTrackers already exist in the whylogs-python, and now they have parity in the java library as well.

StringTrackers accumulate statistical profiles of string tokens in text input features.  Position and frequency information is gathered for each character in a token.  By default strings are broken into tokens at white-space boundaries, but this may be changed by supplying your own tokenizer function.
