### PR TITLE
WHY-3693: protect against exception when scorematrix has no labels

### DIFF
--- a/core/src/main/java/com/whylogs/core/metrics/RegressionMetrics.java
+++ b/core/src/main/java/com/whylogs/core/metrics/RegressionMetrics.java
@@ -6,10 +6,12 @@ import java.util.Map;
 import java.util.Objects;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 
 @RequiredArgsConstructor
 @Getter
+@Slf4j
 public class RegressionMetrics {
   private final String predictionField;
   private final String targetField;
@@ -83,6 +85,7 @@ public class RegressionMetrics {
     }
 
     if ("".equals(msg.getPredictionField()) || "".equals(msg.getTargetField())) {
+      log.warn("Skipping Regression metrics: prediction or target field not set");
       return null;
     }
 

--- a/core/src/main/java/com/whylogs/core/metrics/ScoreMatrix.java
+++ b/core/src/main/java/com/whylogs/core/metrics/ScoreMatrix.java
@@ -225,6 +225,12 @@ public class ScoreMatrix {
       return null;
     }
 
+    if (msg.getLabelsCount() == 0) {
+      // Not a valid scoreMatrix without labels.
+      log.warn("Skipping classification ScoreMatrix: no labels");
+      return null;
+    }
+
     val labels = Lists.<String>newArrayList();
     for (int i = 0; i < msg.getLabelsCount(); i++) {
       labels.add(msg.getLabels(i));

--- a/core/src/main/java/com/whylogs/core/metrics/ScoreMatrix.java
+++ b/core/src/main/java/com/whylogs/core/metrics/ScoreMatrix.java
@@ -225,15 +225,15 @@ public class ScoreMatrix {
       return null;
     }
 
-    if (msg.getLabelsCount() == 0) {
-      // Not a valid scoreMatrix without labels.
-      log.warn("Skipping classification ScoreMatrix: no labels");
-      return null;
-    }
-
     val labels = Lists.<String>newArrayList();
     for (int i = 0; i < msg.getLabelsCount(); i++) {
       labels.add(msg.getLabels(i));
+    }
+
+    if (msg.getLabelsCount() == 0 && msg.getScoresCount() > 0) {
+      // Not valid to have score without labels.
+      log.warn("Skipping classification ScoreMatrix: has scores but no labels");
+      return null;
     }
 
     final int n = labels.size();


### PR DESCRIPTION
Protect ScoreMatrix `fromProtobuf` routine from ArithmeticException exception when message has no labels.
