### PR TITLE
Avoid NPEs when merging profiles with null model metrics

### DIFF
--- a/core/src/main/java/com/whylogs/core/DatasetProfile.java
+++ b/core/src/main/java/com/whylogs/core/DatasetProfile.java
@@ -290,7 +290,10 @@ public class DatasetProfile implements Serializable {
       result.columns.put(column, thisColumn.merge(otherColumn));
     }
 
-    if (this.modelProfile != null) {
+    if (this.modelProfile != null
+        && modelProfile.getMetrics() != null
+        && other.modelProfile != null
+        && other.modelProfile.getMetrics() != null) {
       result.modelProfile = this.modelProfile.merge(other.modelProfile);
     } else if (other.modelProfile != null) {
       result.modelProfile = other.modelProfile.copy();


### PR DESCRIPTION
Caused by: java.lang.NullPointerException
	at com.whylogs.core.ModelProfile.merge(ModelProfile.java:55)
	at com.whylogs.core.DatasetProfile.doMerge(DatasetProfile.java:294)
	at com.whylogs.core.DatasetProfile.merge(DatasetProfile.java:260)