### PR TITLE
WHY-3700: stringtracker merge should handle missing data

### DIFF
--- a/core/src/main/java/com/whylogs/core/statistics/datatypes/CharPosTracker.java
+++ b/core/src/main/java/com/whylogs/core/statistics/datatypes/CharPosTracker.java
@@ -126,6 +126,10 @@ public class CharPosTracker {
   }
 
   public CharPosTracker merge(CharPosTracker other) {
+    if (other == null) {
+      return this;
+    }
+
     if (characterList != other.characterList && (charPosMap == null || other.charPosMap == null)) {
       log.error("Merging two non-empty Character position tracker with different character lists");
     }

--- a/core/src/main/java/com/whylogs/core/statistics/datatypes/StringTracker.java
+++ b/core/src/main/java/com/whylogs/core/statistics/datatypes/StringTracker.java
@@ -117,6 +117,10 @@ public final class StringTracker {
    */
   public StringTracker merge(StringTracker other) {
     ItemsSketch<String> itemsCopy = null;
+    if (other == null) {
+      return this;
+    }
+
     if (this.items != null) {
       val bytes = this.items.toByteArray(ARRAY_OF_STRINGS_SER_DE);
       itemsCopy = ItemsSketch.getInstance(WritableMemory.wrap(bytes), ARRAY_OF_STRINGS_SER_DE);


### PR DESCRIPTION
Stringtracker broke backwards compatibility on merging.
- Test for missing stringtracker or missing charposmap before merging.
- Added unit test for merging with legacy profile.