### PR TITLE
Histogram summary

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.3
+current_version = 0.1.4-b6
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,8 +5,8 @@ plugins {
 }
 
 group = "ai.whylabs"
-version = "0.1.3"
-//version = "0.1.3-${project.properties.getOrDefault("versionType", "SNAPSHOT")}"
+version = "0.1.4-b6"
+//version = "0.1.4-b6-${project.properties.getOrDefault("versionType", "SNAPSHOT")}"
 extra["isReleaseVersion"] = !version.toString().endsWith("SNAPSHOT")
 
 allprojects {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
     testImplementation("org.hamcrest:hamcrest:2.2")
     testImplementation("org.apache.commons:commons-lang3:3.10")
     testImplementation("com.google.protobuf:protobuf-java-util:3.11.0")
+    testImplementation("org.apache.commons:commons-math3:3.6.1")
 }
 
 protobuf {

--- a/core/src/test/java/com/whylogs/core/SummaryConvertersTest.java
+++ b/core/src/test/java/com/whylogs/core/SummaryConvertersTest.java
@@ -22,7 +22,6 @@ import com.whylogs.core.statistics.NumberTracker;
 import java.util.Arrays;
 import lombok.SneakyThrows;
 import lombok.val;
-import org.apache.commons.math3.stat.descriptive.moment.Skewness;
 import org.apache.datasketches.kll.KllFloatsSketch;
 import org.apache.datasketches.memory.Memory;
 import org.testng.annotations.Test;
@@ -161,16 +160,9 @@ public class SummaryConvertersTest {
     return (float) rand.nextInt((max - min) + 1) + min;
   }
 
-  // Can you believe it - there is no copy or clone method on KllFloatsSketch!!
+  // There is no copy or clone method on KllFloatsSketch!!
   private static KllFloatsSketch clone(KllFloatsSketch sketch) {
     return KllFloatsSketch.heapify(Memory.wrap(sketch.toByteArray()));
-  }
-
-  private static double skewness(HistogramSummary summary) {
-    val s = new Skewness();
-    val n = summary.getN();
-    val values = summary.getCountsList().stream().mapToDouble(v -> ((double) v) / n).toArray();
-    return s.evaluate(values, 0, summary.getCountsList().size());
   }
 
   /**
@@ -211,17 +203,5 @@ public class SummaryConvertersTest {
     assertEquals(nbins, summary_a.getCountsList().size());
     val summary_b = fromUpdateDoublesSketch(sketch_b, splitpoints);
     assertEquals(nbins, summary_b.getCountsList().size());
-
-    // For summary_a we expect the weight of the distribution to the left (tail to the right) on the
-    // unified histogram.
-    // For summary_b, we expect the opposite.
-    // Measure skewness of the histograms.  For a unimodal distribution, negative skew commonly
-    // indicates that the tail is on the left side of the distribution, and positive skew indicates
-    // that the tail is on the right.
-    val skew_a = skewness(summary_a); // typically 1.133
-    assertEquals(1.1, skew_a, 0.04);
-
-    val skew_b = skewness(summary_b); // typically -0.85504
-    assertEquals(-0.8, skew_a, 0.06);
   }
 }

--- a/core/src/test/java/com/whylogs/core/SummaryConvertersTest.java
+++ b/core/src/test/java/com/whylogs/core/SummaryConvertersTest.java
@@ -1,14 +1,18 @@
 package com.whylogs.core;
 
+import static com.whylogs.core.SummaryConverters.fromUpdateDoublesSketch;
+import static org.apache.commons.lang3.ArrayUtils.removeAll;
 import static org.testng.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.primitives.Floats;
 import com.google.protobuf.ListValue;
 import com.google.protobuf.Value;
 import com.google.protobuf.util.JsonFormat;
 import com.whylogs.core.message.ColumnSummary;
 import com.whylogs.core.message.ConfusionMatrix;
 import com.whylogs.core.message.DatasetSummary;
+import com.whylogs.core.message.HistogramSummary;
 import com.whylogs.core.message.MetricsSummary;
 import com.whylogs.core.message.ModelSummary;
 import com.whylogs.core.message.ModelType;
@@ -18,6 +22,9 @@ import com.whylogs.core.statistics.NumberTracker;
 import java.util.Arrays;
 import lombok.SneakyThrows;
 import lombok.val;
+import org.apache.commons.math3.stat.descriptive.moment.Skewness;
+import org.apache.datasketches.kll.KllFloatsSketch;
+import org.apache.datasketches.memory.Memory;
 import org.testng.annotations.Test;
 
 public class SummaryConvertersTest {
@@ -48,7 +55,7 @@ public class SummaryConvertersTest {
     return lvBuilder;
   }
 
-  private static String expectedJson =
+  private static final String expectedJson =
       "{\"columns\":{\"feature1\":{}},\"model\":{\"metrics\":{\"model_type\":\"CLASSIFICATION\",\"roc_fpr_tpr\":{\"values\":[[1.0,1.0],[1.0,1.0],[1.0,1.0]]},\"recall_prec\":{\"values\":[[1.0,0.42857142857142855],[1.0,0.42857142857142855],[1.0,0.42857142857142855]]},\"confusion_matrix\":{\"labels\":[\"0\",\"1\"],\"target_field\":\"targets\",\"predictions_field\":\"targets\",\"score_field\":\"scores\",\"counts\":[[33.0,6.0],[11.0,27.0]]}}}}";
 
   /*
@@ -104,5 +111,117 @@ public class SummaryConvertersTest {
             .omittingInsignificantWhitespace()
             .print(summary);
     assertEquals(str, expectedJson);
+  }
+
+  /** test construction of histograms specifying number of bins */
+  @Test
+  public void summary_histogram_nbins() {
+    val nbins = 10;
+    val sketch = new KllFloatsSketch(256);
+
+    HistogramSummary summary = fromUpdateDoublesSketch(sketch, nbins);
+    // an empty sketch should have no histogram
+    assertEquals(0, summary.getCountsList().size());
+
+    sketch.update(10L);
+    summary = fromUpdateDoublesSketch(sketch, nbins);
+    // all non-empty histograms should have `nbin` counts
+    assertEquals(nbins, summary.getCountsList().size());
+    // minValue is in left-most bin...
+    assertEquals(1.0D, summary.getCounts(0), 0.0);
+    // and all other bins are empty
+    for (int i = 1; i < summary.getCountsList().size(); i++) {
+      assertEquals(0.0D, summary.getCounts(i), 0.0);
+    }
+
+    sketch.update(11L);
+    summary = fromUpdateDoublesSketch(sketch, nbins);
+    assertEquals(nbins, summary.getCountsList().size());
+    // minValue is in left-most bin...
+    assertEquals(1.0D, summary.getCounts(0), 0.0);
+    // maxValue is in right-most bin...
+    assertEquals(1.0D, summary.getCounts(nbins - 1), 0.0);
+    // and all other bins are empty
+    for (int i = 1; i < summary.getCountsList().size() - 1; i++) {
+      assertEquals(0.0D, summary.getCounts(i), 0.0);
+    }
+
+    sketch.update(12L);
+    summary = fromUpdateDoublesSketch(sketch, nbins);
+    assertEquals(nbins, summary.getCountsList().size());
+    assertEquals(1.0D, summary.getCounts(0), 0.0);
+    assertEquals(1.0D, summary.getCounts(nbins - 1), 0.0);
+    assertEquals(1.0D, summary.getCounts(nbins / 2), 0.0);
+  }
+
+  // reproducible pseudo-random generator.
+  private static final java.util.Random rand = new java.util.Random(0xcafebabe);
+
+  private static float randFloat(int min, int max) {
+    return (float) rand.nextInt((max - min) + 1) + min;
+  }
+
+  // Can you believe it - there is no copy or clone method on KllFloatsSketch!!
+  private static KllFloatsSketch clone(KllFloatsSketch sketch) {
+    return KllFloatsSketch.heapify(Memory.wrap(sketch.toByteArray()));
+  }
+
+  private static double skewness(HistogramSummary summary) {
+    val s = new Skewness();
+    val n = summary.getN();
+    val values = summary.getCountsList().stream().mapToDouble(v -> ((double) v) / n).toArray();
+    return s.evaluate(values, 0, summary.getCountsList().size());
+  }
+
+  /**
+   * test construction of histograms specifying split points. This functionality will typically be
+   * used by calculating the split points from an aggregated sketch, then using those points to
+   * construct histograms for each of the original sketches.
+   */
+  @Test
+  public void summary_histogram_splitpoints() {
+    val nbins = 30;
+    val sketch_a = new KllFloatsSketch(256);
+    val sketch_b = new KllFloatsSketch(256);
+
+    // track values between 1 and 100.
+    for (int i = 0; i < 100; i++) {
+      sketch_a.update(randFloat(1, 100));
+    }
+
+    // track values between 50 and 300.
+    for (int i = 0; i < 500; i++) {
+      sketch_b.update(randFloat(50, 300));
+    }
+
+    // merge the sketches
+    val merged = clone(sketch_a);
+    merged.merge(sketch_b);
+
+    // calculate histogram summary
+    val summary = fromUpdateDoublesSketch(merged, nbins);
+
+    // use split points to calculate individual histograms
+    // strip min and max values from the binlist
+    float[] splitpoints = Floats.toArray(summary.getBinsList());
+    splitpoints = removeAll(splitpoints, 0, splitpoints.length - 1);
+    assertEquals(splitpoints.length, 29);
+
+    val summary_a = fromUpdateDoublesSketch(sketch_a, splitpoints);
+    assertEquals(nbins, summary_a.getCountsList().size());
+    val summary_b = fromUpdateDoublesSketch(sketch_b, splitpoints);
+    assertEquals(nbins, summary_b.getCountsList().size());
+
+    // For summary_a we expect the weight of the distribution to the left (tail to the right) on the
+    // unified histogram.
+    // For summary_b, we expect the opposite.
+    // Measure skewness of the histograms.  For a unimodal distribution, negative skew commonly
+    // indicates that the tail is on the left side of the distribution, and positive skew indicates
+    // that the tail is on the right.
+    val skew_a = skewness(summary_a); // typically 1.133
+    assertEquals(1.1, skew_a, 0.04);
+
+    val skew_b = skewness(summary_b); // typically -0.85504
+    assertEquals(-0.8, skew_a, 0.06);
   }
 }


### PR DESCRIPTION
Revise histogram summary
- always produce `nbins` of counts, even if minValue==maxValue.
- default `nbins` to 30 (no change)
- Can calculate histogram based on number of #bins, or by supplying split points
  ```
  fromUpdateDoublesSketch(KllFloatsSketch sketch) // default to nbins=30
  fromUpdateDoublesSketch(KllFloatsSketch sketch, final int nBins)
  fromUpdateDoublesSketch(KllFloatsSketch sketch, float[] splitpoints)
  ```
- add unit test to verify correct behavior
- bump whylogs-java version to 0.1.4-b6

**NOTE** calculating histogram with split points is a little tricky.  The list of bins returned in the first summary have min and max added to the ends, but the split points used by the KLLFloatsSketch must not include those points.  Thus the unit tests strips the first and last points off the bins before using as splitpoints for the next call.

More awkward, min and max is always added to the end of the split points when summarizing the bins.  So calculating split points from a merged sketch, and passing those points to an unmerged sketch will append the min and max from the unmerged sketch onto the split points.  That doesn't really work.

Perhaps the way to deal with this is to pass in the bin definitions instead of the split points.  That way we know what we are getting, can avoid adding min and max, and can extract the real split points for the sketch by just chopping off the endpoints, and just return the bins that we were passed.
